### PR TITLE
fix: set LIMIT_ORDER_TYPEHASH as constant

### DIFF
--- a/contracts/limitOrder/LimitOrderBook.sol
+++ b/contracts/limitOrder/LimitOrderBook.sol
@@ -27,7 +27,7 @@ contract LimitOrderBook is ILimitOrderBook, BlockContext, ReentrancyGuardUpgrade
     }
 
     // solhint-disable-next-line func-name-mixedcase
-    bytes32 public LIMIT_ORDER_TYPEHASH =
+    bytes32 public constant LIMIT_ORDER_TYPEHASH =
         keccak256(
             // solhint-disable-next-line max-line-length
             "LimitOrder(uint256 salt,address trader,address baseToken,bool isBaseToQuote,bool isExactInput,uint256 amount,uint256 oppositeAmountBound,uint256 deadline,bool reduceOnly)"


### PR DESCRIPTION
This PR is to fix LIMIT_ORDER_TYPEHASH as constant variable.
Otherwise, it will be failed to deploy due to the following error.

```
Error: Contract `LimitOrderBook` is not upgrade safe

contracts/limitOrder/LimitOrderBook.sol:30: Variable `LIMIT_ORDER_TYPEHASH` is assigned an initial value
```