### PR TITLE
Release/v1.4.1 no dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2022-08-01
+
+### Removed
+
+- Remove `DelegatableVault`
+
 ## [1.4.0] - 2022-07-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -39,11 +39,14 @@
     "lint-tests": "if grep -qr 'test' -e '.only('; then echo 'found .only() in tests'; exit 1; else echo 'not found .only() in tests'; fi",
     "prepack": "ts-node --files scripts/prepack.ts"
   },
-  "dependencies": {
-    "@perp/curie-contract": "git+ssh://git@github.com:perpetual-protocol/perp-lushan.git#c11c3094e79ecedce7eb9935a87a3b08a4d73b31",
-    "@perp/perp-oracle-contract": "0.4.3"
-  },
   "devDependencies": {
+    "@perp/curie-contract": "1.4.0",
+    "@perp/perp-oracle-contract": "0.4.3",
+    "@chainlink/contracts": "0.1.7",
+    "@openzeppelin/contracts": "3.4.1-solc-0.7-2",
+    "@openzeppelin/contracts-upgradeable": "3.4.2",
+    "@uniswap/v3-core": "https://github.com/Uniswap/uniswap-v3-core/tarball/v1.0.0",
+    "@uniswap/v3-periphery": "1.0.1",
     "@defi-wonderland/smock": "2.0.7",
     "@metamask/eth-sig-util": "4.0.1",
     "@nomiclabs/hardhat-ethers": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perp/curie-periphery-contract",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Perpetual Protocol Curie (v2) periphery contracts",
   "license": "GPL-3.0-or-later",
   "author": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,31 +841,15 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.2.tgz#2c2a1b0fa748235a1f495b6489349776365c51b3"
   integrity sha512-mDlBS17ymb2wpaLcrqRYdnBAmP1EwqhOXMvqWk2c5Q1N1pm5TkiCtXM9Xzznh4bYsQBq0aIWEkFFE2+iLSN1Tw==
 
-"@openzeppelin/contracts@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.0.tgz#9a1669ad5f9fdfb6e273bb5a4fed10cb4cc35eb0"
-  integrity sha512-qh+EiHWzfY/9CORr+eRUkeEUP1WiFUcq3974bLHwyYzLBUtK6HPaMkIUHi74S1rDTZ0sNz42DwPc5A4IJvN3rg==
-
 "@openzeppelin/contracts@3.4.1-solc-0.7-2":
   version "3.4.1-solc-0.7-2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
-"@perp/curie-contract@git+ssh://git@github.com:perpetual-protocol/perp-lushan.git#c11c3094e79ecedce7eb9935a87a3b08a4d73b31":
+"@perp/curie-contract@1.4.0":
   version "1.4.0"
-  resolved "git+ssh://git@github.com:perpetual-protocol/perp-lushan.git#c11c3094e79ecedce7eb9935a87a3b08a4d73b31"
-  dependencies:
-    "@chainlink/contracts" "0.1.7"
-    "@openzeppelin/contracts" "3.4.0"
-    "@openzeppelin/contracts-upgradeable" "3.4.2"
-    "@perp/perp-oracle-contract" "0.4.1"
-    "@uniswap/v3-core" "https://github.com/Uniswap/uniswap-v3-core/tarball/v1.0.0"
-    "@uniswap/v3-periphery" "1.0.1"
-
-"@perp/perp-oracle-contract@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@perp/perp-oracle-contract/-/perp-oracle-contract-0.4.1.tgz#f6545bf0084ea6f09625b0e662251e8569338c66"
-  integrity sha512-DSpOf9CsyOkUwLRKrpc1ye41gMarulfsuq8L5hVvt0ANtLpHHRXo0lCxzsC3tn+5TpFHwBl8oCxX+BJiZvixig==
+  resolved "https://registry.yarnpkg.com/@perp/curie-contract/-/curie-contract-1.4.0.tgz#674b26564badca61512b158c66f5eb2bbc4d88f5"
+  integrity sha512-uB/7fxBKALEB9GQZE2gwMp1PTPuMuDcOu1R82G2sfqW4ybgo60eHPXYDW4X5q0V2nDp8o0D9Q7RegsRY3gpnnw==
 
 "@perp/perp-oracle-contract@0.4.3":
   version "0.4.3"


### PR DESCRIPTION
- Rollback to `devDependencies`
- Ready to release v1.4.1 (just remove `DelegatableVault`)